### PR TITLE
fix gvent build cause by not support python version 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ termcolor==1.1.0
 flask==1.1.4
 requests==2.28.1
 chardet==3.0.4
-gevent==21.12.0
+gevent==22.08.0
 flask_basicauth==0.2.0
 flask_sockets==0.2.1
 beautifulsoup4==4.11.1


### PR DESCRIPTION
Fixes #222 .

It seems docker build fail is because 

gevent==21.12.0 not support python 3.11 build,

This PR is trying to catch-up newest packages. If this repository will stay in Python 3.8 or Python 3.9, please consider change

https://github.com/miyouzi/aniGamerPlus/blob/a2387121a47a2d83e268875c829a194606564f9a/Dockerfile#L1

into [3.8-slim](https://github.com/docker-library/python/blob/d24131ca9b820cd7a83ec7920b49bd0463d4db92/3.8/slim-bullseye/Dockerfile)